### PR TITLE
fixed betting.facing_bet_* functions

### DIFF
--- a/kuhn3p/betting.py
+++ b/kuhn3p/betting.py
@@ -66,10 +66,10 @@ def facing_bet(state):
     return can_fold(state)
 
 def facing_bet_call(state):
-    return to_decision(state) == 2
+    return to_decision(state) == 3
 
 def facing_bet_fold(state):
-    return to_decision(state) == 3
+    return to_decision(state) == 2
 
 def call_closes_action(state):
     return facing_bet_call(state) or facing_bet_fold(state) 

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,19 @@
+import pytest
+from kuhn3p import betting
+
+def test_to_string():
+    assert betting.num_internal() == 12
+    assert betting.num_terminals() == 13
+    for state in range(betting.num_internal(), betting.num_internal() + betting.num_terminals()):
+        assert betting.string_to_state(betting.to_string(state)) == state
+
+def test_facing_funcs():
+    for state in range(6, 9):
+        assert betting.facing_bet_fold(state)
+    for state in range(9, 12):
+        assert betting.facing_bet_call(state)
+    
+        
+
+        
+


### PR DESCRIPTION
When I run this code:

```
from kuhn3p import betting
for state in range(6, 12):
    print (state)
    nstate = betting.act(state,0)
    print betting.to_string(nstate)
```

I get this result:

```
6
crfc
7
ccrfc
8
rfc
9
crcc
10
ccrcc
11
rcc
```

This fix makes sure that `betting.facing_bet_fold()` and `betting.facing_bet_call` give the correct result for these internal states.  I also added a test script to test these cases.
